### PR TITLE
サービスタイプと、ディスプレイ名について長さ制限を取り除いた

### DIFF
--- a/Sources/BwNearPeer/NearPeer.swift
+++ b/Sources/BwNearPeer/NearPeer.swift
@@ -68,7 +68,9 @@ public class NearPeer: NearPeerProtocol {
         }
 
         if serviceType.count > 15 {
-            assertionFailure("serviceTypeは、15文字までです \(serviceType)")
+            // assertionFailure("serviceTypeは、15文字までです \(serviceType)")
+            // print("serviceTypeは、15文字までです \(serviceType)")
+            // return String(serviceType.prefix(15))
         }
 
         // Must be 1–15 characters long の他は未実装
@@ -85,7 +87,9 @@ public class NearPeer: NearPeerProtocol {
         }
 
         if displayName.count > 63 {
-            assertionFailure("serviceTypeは、63文字までです: \(displayName)")
+            // assertionFailure("serviceTypeは、63文字までです: \(displayName)")
+            // print("serviceTypeは、63文字までです: \(displayName)")
+            // return String(displayName.prefix(63))
         }
 
         return displayName


### PR DESCRIPTION
## やったこと

サービスタイプと、ディスプレイ名について長さ制限を取り除いた

## 理由

- 長さ制限に掛かったことが分かりずらいし、修正もしていない
- 修正しなくて長いまま使っても問題ないようだ
  - クレームワーク内で対応されているよう
- UUIDを追加しており、これが中途で切られても大きな問題にはならない